### PR TITLE
feat: Hide taint error messages, order error messages by priority

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,22 @@
+default:
+  tags:
+    - ord1-tenant
+
+stages:
+  - build
+  - push
+
+build:
+  stage: build
+  script:
+    - make quick-release-images
+
+scheduler:
+  stage: push
+  needs:
+    - job: build
+      optional: false
+  script:
+    - TAG=$(docker load -i _output/release-images/amd64/kube-scheduler.tar | cut -d' ' -f3)
+    - docker tag $TAG registry.gitlab.com/coreweave/kubernetes:kube-scheduler-$CI_COMMIT_SHORT_SHA
+    - docker push registry.gitlab.com/coreweave/kubernetes:kube-scheduler-$CI_COMMIT_SHORT_SHA

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,8 @@ default:
   tags:
     - ord1-tenant
 
+image: ubuntu:22.10
+
 services:
   - docker:dind
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,24 +2,19 @@ default:
   tags:
     - ord1-tenant
 
+services:
+  - docker:dind
+
 stages:
   - build
-  - push
 
 build:
   stage: build
   before_script:
     - apt update
-    - apt install make golang -y
+    - apt install make rsync -y
   script:
     - make quick-release-images
-
-scheduler:
-  stage: push
-  needs:
-    - job: build
-      optional: false
-  script:
     - TAG=$(docker load -i _output/release-images/amd64/kube-scheduler.tar | cut -d' ' -f3)
     - docker tag $TAG registry.gitlab.com/coreweave/kubernetes:kube-scheduler-$CI_COMMIT_SHORT_SHA
     - docker push registry.gitlab.com/coreweave/kubernetes:kube-scheduler-$CI_COMMIT_SHORT_SHA

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,9 @@ stages:
 
 build:
   stage: build
+  before_script:
+    - apt update
+    - apt install make golang -y
   script:
     - make quick-release-images
 

--- a/pkg/coreweave/reasons.go
+++ b/pkg/coreweave/reasons.go
@@ -1,0 +1,62 @@
+package coreweave
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type Reason struct {
+	Reason   string
+	Priority int
+	Count    int
+}
+
+type Reasons []Reason
+
+func (r Reasons) Len() int {
+	return len(r)
+}
+func (r Reasons) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+func (r Reasons) Less(i, j int) bool {
+	return r[i].Priority < r[j].Priority
+}
+
+func (r Reasons) AsStrings() []string {
+	sort.Sort(r)
+	var reasons []string
+	for _, v := range r {
+		reasons = append(reasons, fmt.Sprintf("%v %v", v.Count, v.Reason))
+	}
+	return reasons
+}
+
+// reasonPriority accepts a string to give the error priority 0-100
+func reasonPriority(reason string) int {
+	if strings.Contains(reason, "volume") {
+		return 1
+	} else if strings.Contains(reason, "Insufficient memory") {
+		return 5
+	} else if strings.Contains(reason, "Insufficient cpu") {
+		return 6
+	} else if strings.Contains(reason, "node affinity") {
+		return 10
+	} else if strings.Contains(reason, "taints") {
+		return 20
+	}
+	return 99
+}
+
+func SanitizeTenantReasons(reasons map[string]int) Reasons {
+	var newReasons Reasons
+	for k, v := range reasons {
+		newReasons = append(newReasons, Reason{
+			Reason:   k,
+			Priority: reasonPriority(k),
+			Count:    v,
+		})
+	}
+	return newReasons
+}

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -149,10 +149,6 @@ func (g *genericScheduler) Schedule(ctx context.Context, fwk framework.Framework
 		return result, ErrNoNodesAvailable
 	}
 
-	if strings.Contains(pod.Namespace, "tenant") {
-		ctx = context.WithValue(ctx, "tenant", true)
-	}
-
 	feasibleNodes, filteredNodesStatuses, err := g.findNodesThatFitPod(ctx, fwk, state, pod)
 	if err != nil {
 		return result, err

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -70,7 +70,7 @@ func (pl *TaintToleration) Filter(ctx context.Context, state *framework.CycleSta
 		taint.Key, taint.Value)
 
 	if coreweave.HiddenTaint(pod.Namespace, taint.Key) {
-		errReason = fmt.Sprintf("node(s) had taint that the pod didn't tolerate")
+		errReason = fmt.Sprintf("node(s) had multiple taints that the pod didn't tolerate")
 	}
 
 	return framework.NewStatus(framework.UnschedulableAndUnresolvable, errReason)


### PR DESCRIPTION
- Hides taint error messages by adding them to `CW_HIDDEN_TAINTS` environment variable. 
- Prioritized error order based on simple reason string search