### PR TITLE
Exclude mounts from mount refs that don't share a parent

### DIFF
--- a/staging/src/k8s.io/mount-utils/mount_linux.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux.go
@@ -646,6 +646,7 @@ func SearchMountPoints(hostSource, mountInfoPath string) ([]string, error) {
 	}
 
 	mountID := 0
+	parentID := -1
 	rootPath := ""
 	major := -1
 	minor := -1
@@ -657,6 +658,7 @@ func SearchMountPoints(hostSource, mountInfoPath string) ([]string, error) {
 		if hostSource == mis[i].MountPoint || PathWithinBase(hostSource, mis[i].MountPoint) {
 			// If it's a mount point or path under a mount point.
 			mountID = mis[i].ID
+			parentID = mis[i].ParentID
 			rootPath = filepath.Join(mis[i].Root, strings.TrimPrefix(hostSource, mis[i].MountPoint))
 			major = mis[i].Major
 			minor = mis[i].Minor
@@ -670,8 +672,8 @@ func SearchMountPoints(hostSource, mountInfoPath string) ([]string, error) {
 
 	var refs []string
 	for i := range mis {
-		if mis[i].ID == mountID {
-			// Ignore mount entry for mount source itself.
+		if mis[i].ID == mountID || (mis[i].ParentID != parentID && mountID != mis[i].ParentID) {
+			// Ignore mount entry for mount source itself, or if they don't share the same parent and the mount source isn't its parent.
 			continue
 		}
 		if mis[i].Root == rootPath && mis[i].Major == major && mis[i].Minor == minor {

--- a/staging/src/k8s.io/mount-utils/mount_linux_test.go
+++ b/staging/src/k8s.io/mount-utils/mount_linux_test.go
@@ -319,6 +319,7 @@ func TestSearchMountPoints(t *testing.T) {
 40 29 0:34 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:21 - cgroup cgroup rw,cpuset
 41 29 0:35 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:22 - cgroup cgroup rw,net_cls,net_prio
 58 25 7:1 / /mnt/disks/blkvol1 rw,relatime shared:38 - ext4 /dev/loop1 rw,data=ordere
+90 30 0:100 / /var/lib/test-mounts/test1 rw,relatime shared:100 - tmpfs tmpfs rw,size=5120k
 `
 
 	testcases := []struct {
@@ -420,6 +421,13 @@ func TestSearchMountPoints(t *testing.T) {
 `,
 			[]string{"/var/lib/kubelet/pods/f19fe4e2-5a63-11e8-962f-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-test",
 				"/var/lib/kubelet/pods/4854a48b-5a64-11e8-962f-000c29bb0377/volumes/kubernetes.io~local-volume/local-pv-test"},
+			nil,
+		},
+		{
+			"dir-bindmounted-ignore-diff-parent",
+			"/var/lib/test-mounts/test1",
+			base + `91 42 0:100 / /mnt/lib/test-mounts/test1 rw,relatime shared:100 - tmpfs tmpfs rw,size=5120k`,
+			nil,
 			nil,
 		},
 	}


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
This fixes an issue where when something like /var/lib/kubelet is bindmounted to somewhere else on disk. When this happens things like staging volumes for ReadWriteMany volumes will always return a reference even when there are none.

This causes tons of staging volumes to exist on the hosts that will never be cleaned up.

Which issue(s) this PR fixes:


Special notes for your reviewer:
Does this PR introduce a user-facing change?
Fixed a bug where bind mounting the staging volume path would cause Kubelet to never tell the CSI to unstage a volume on a node.
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None.